### PR TITLE
(BUG) adding vega-wmf-loader

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,7 @@
     "chronicle": "~1.0.10",
     "fontawesome": "~4.5.0",
     "vega-lite-ui": "~0.11.0",
+    "vega-wmf-loader": "git+http://git@github.com/nyurik/vega-wmf-loader",
     "zeptojs": "~1.1.6",
     "z-schema": "~3.16.1"
   }


### PR DESCRIPTION
I created a package, and tried loading it into bower, but i think it needs something else to be added to the `dist` dir.  `bower install` + `npm run-script build` only download it, but do not change the code it seems.
